### PR TITLE
Added label default class

### DIFF
--- a/Resources/views/CRUD/form.html.twig
+++ b/Resources/views/CRUD/form.html.twig
@@ -19,3 +19,21 @@
         {% endif %}
     {% endspaceless %}
 {% endblock form_errors %}
+
+{% block form_label %}
+    {% spaceless %}
+        {% if label is not sameas(false) %}
+            {% if not compound %}
+                {% set label_attr = label_attr|merge({'for': id}) %}
+            {% endif %}
+            {% if required %}
+                {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+            {% endif %}
+            {% if label is empty %}
+                {% set label = name|humanize %}
+            {% endif %}
+            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' control-label')|trim}) %}
+            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+        {% endif %}
+    {% endspaceless %}
+{% endblock form_label %}


### PR DESCRIPTION
After this change you should remove `'label_attr' => array('class' => 'control-label'),` option from any form used in admin panel. 
