### PR TITLE
Passing form options to form template

### DIFF
--- a/Resources/views/CRUD/create.html.twig
+++ b/Resources/views/CRUD/create.html.twig
@@ -9,7 +9,7 @@
         <div class="panel panel-default">
             <div class="panel-body">
                 <h3 id="page-header">{{ title|trans({}, 'FSiAdminBundle') }}</h3>
-                <form action="{{ path('fsi_admin_crud_create', {element: element.id}) }}" method="post" {{ form_enctype(form) }} class="form-horizontal">
+                {{ form_start(form, { action: path('fsi_admin_crud_create', { element: element.id }), 'attr': { class: 'form-horizontal' }|merge(form.vars.attr) }) }}
                     {{ form_widget(form) }}
                     <div class="form-group">
                         <div class="col-lg-offset-2 col-lg-10">
@@ -20,7 +20,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </form>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>

--- a/Resources/views/CRUD/delete.html.twig
+++ b/Resources/views/CRUD/delete.html.twig
@@ -12,7 +12,7 @@
         </div>
         {% endblock message %}
         {% block form %}
-        <form action="{{ path('fsi_admin_crud_delete', {element: element.id}) }}" method="post" {{ form_enctype(form) }} class="form-horizontal">
+        {{ form_start(form, { action: path('fsi_admin_crud_delete', { element: element.id }), 'attr': { class: 'form-horizontal' }|merge(form.vars.attr) }) }}
             {% for index in indexes %}
             <input type="hidden" value="{{ index }}" name="indexes[]"/>
             {% endfor %}
@@ -20,7 +20,7 @@
             <input type="hidden" name="_method" value="DELETE" />
             <button type="submit" class="btn btn-success" name="confirm">{{ 'crud.delete.form.confirm.label'|trans({}, 'FSiAdminBundle') }}</button>
             <button type="submit" class="btn btn-danger" name="cancel">{{ 'crud.delete.form.cancel.label'|trans({}, 'FSiAdminBundle') }}</button>
-        </form>
+        {{ form_end(form) }}
         {% endblock form %}
     </div>
 {% endblock %}

--- a/Resources/views/CRUD/edit.html.twig
+++ b/Resources/views/CRUD/edit.html.twig
@@ -13,7 +13,7 @@
                 {% else %}
                 <h3 id="page-header">{{ title|trans({}, 'FSiAdminBundle') }}</h3>
                 {% endif %}
-                <form action="{{ path('fsi_admin_crud_edit', {element: element.id, id: id}) }}" method="post" {{ form_enctype(form) }} class="form-horizontal">
+                {{ form_start(form, { action: path('fsi_admin_crud_edit', { element: element.id, id: id }), 'attr': { class: 'form-horizontal' }|merge(form.vars.attr) }) }}
                     {{ form_widget(form) }}
                     <div class="form-group">
                         <div class="col-lg-offset-2 col-lg-10">
@@ -24,7 +24,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </form>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>

--- a/Resources/views/Resource/resource.html.twig
+++ b/Resources/views/Resource/resource.html.twig
@@ -9,7 +9,7 @@
         <div class="panel panel-default">
             <div class="panel-body">
                 <h3 id="page-header">{{ title|trans({}, 'FSiAdminBundle') }}</h3>
-                <form action="{{ path('fsi_admin_resource', {element: element.id}) }}" method="post" {{ form_enctype(form) }} class="form-horizontal">
+                {{ form_start(form, { action: path('fsi_admin_resource', { element: element.id }), 'attr': { class: 'form-horizontal' }|merge(form.vars.attr) }) }}
                     {{ form_widget(form) }}
                     <div class="form-group">
                         <div class="col-lg-offset-2 col-lg-10">
@@ -17,7 +17,7 @@
                             <button type="reset" class="btn btn-primary">{{ 'resource.button.reset'|trans({}, 'FSiAdminBundle')  }}</button>
                         </div>
                     </div>
-                </form>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
There is method `AbstractResource::getResourceFormOptions` which return form options array.

This way we can customize form html ID: 

``` php
    public function getResourceFormOptions()
    {
        return array(
            'attr' => array(
                'id' => 'process-form',
            )
        );
    }
```

Due to part of template below, some part of customization made in `getResourceFormOptions` is lost. 

```
<form action="{{ path('fsi_admin_resource', {element: element.id}) }}" method="post" {{ form_enctype(form) }} class="form-horizontal">
```

I propose to use `form_start` twig function.
