### PR TITLE
Change locale route path is more specific

### DIFF
--- a/Resources/config/routing/admin.yml
+++ b/Resources/config/routing/admin.yml
@@ -4,7 +4,7 @@ fsi_admin:
         _controller: admin.controller.admin:indexAction
 
 fsi_admin_locale:
-    path: /{_locale}
+    path: /locale/{_locale}
     defaults:
         _controller: admin.controller.admin:indexAction
 


### PR DESCRIPTION
This is required because of some security issues that appears when path is /{_locale}  
