### PR TITLE
Updating the documentation

### DIFF
--- a/Resources/doc/embedding_element.md
+++ b/Resources/doc/embedding_element.md
@@ -436,7 +436,7 @@ And ``@AcmeDemo/Admin/user_edit.html.twig`` file
 {{ parent() }}
 <div class="col-lg-12">
     <h1>User invoices</h1>
-    {% render(controller('FSiAdminBundle:CRUD:List', {'element': element.invoices(form.vars.data)})) %}
+    {% render(controller('admin.controller.crud:ListAction', {'element': element.invoices(form.vars.data)})) %}
 </div>
 {% endblock %}
 ```


### PR DESCRIPTION
Since FSiAdminBundle:CRUD controller is defined as service and takes 5 arguments in the constructor, FSiAdminBundle:CRUD:List produces error.
