### PR TITLE
cancel delete fix

### DIFF
--- a/Behat/Context/CRUDContext.php
+++ b/Behat/Context/CRUDContext.php
@@ -422,11 +422,11 @@ class CRUDContext extends PageObjectContext implements KernelAwareInterface
     }
 
     /**
-     * @When /^I press "Yes"$/
+     * @When /^I press "(Yes|No)"$/
      */
-    public function iPress()
+    public function iPress($name)
     {
-        $this->getPage('News delete confirmation')->pressButton('Yes');
+        $this->getPage('News delete confirmation')->pressButton($name);
     }
 
     /**

--- a/Behat/Context/DataContext.php
+++ b/Behat/Context/DataContext.php
@@ -145,6 +145,23 @@ class DataContext extends BehatContext implements KernelAwareInterface
         )))->toBe(null);
     }
 
+    /**
+     * @Given /^news "([^"]*)" should exist in database$/
+     */
+    public function newsShouldExistInDatabase($title)
+    {
+        expect($this->getEntityRepository('FSi\FixturesBundle\Entity\News')->findOneBy(array(
+            'title' => $title
+        )))->toNotBe(null);
+    }
+
+    /**
+     * @Given /^there should be (\d+) news in database$/
+     */
+    public function thereShouldBeThatManyNewsInDatabase($count)
+    {
+        expect(count($this->getEntityRepository('FSi\FixturesBundle\Entity\News')->findAll()))->toBe((int) $count);
+    }
 
     /**
      * @Given /^there should not be any news in database$/

--- a/Doctrine/Admin/Context/Delete/Request/FormValidRequestHandler.php
+++ b/Doctrine/Admin/Context/Delete/Request/FormValidRequestHandler.php
@@ -54,7 +54,9 @@ class FormValidRequestHandler extends AbstractFormRequestHandler
                     return $event->getResponse();
                 }
             }
+        }
 
+        if ($request->request->has('confirm') || $request->request->has('cancel')) {
             return new RedirectResponse($this->router->generate(
                 'fsi_admin_crud_list',
                 array('element' => $event->getElement()->getId())

--- a/features/crud/crud_list_delete.feature
+++ b/features/crud/crud_list_delete.feature
@@ -37,6 +37,20 @@ Feature: Deleting existing object
     And news "News 1" should not exist in database anymore
 
   @javascript
+  Scenario: Cancel delete single news
+    Given I am on the "News list" page
+    When I press checkbox in first column in first row
+    And I choose action "Delete" from actions
+    And I press confirmation button "Ok"
+    Then I should be redirected to confirmation page with message
+    """
+    Are you sure you want to delete 1 from selected elements?
+    """
+    When I press "No"
+    Then I should be redirected to "News list" page
+    And news "News 1" should exist in database
+
+  @javascript
   Scenario: Delete all elements from page
     Given I am on the "News list" page
     When I press checkbox in first column header
@@ -49,3 +63,17 @@ Feature: Deleting existing object
     When I press "Yes"
     Then I should be redirected to "News list" page
     And there should not be any news in database
+
+  @javascript
+  Scenario: Cancel delete all elements from page
+    Given I am on the "News list" page
+    When I press checkbox in first column header
+    And I choose action "Delete" from actions
+    And I press confirmation button "Ok"
+    Then I should be redirected to confirmation page with message
+    """
+    Are you sure you want to delete 3 from selected elements?
+    """
+    When I press "No"
+    Then I should be redirected to "News list" page
+    And there should be 3 news in database

--- a/spec/FSi/Bundle/AdminBundle/Doctrine/Admin/Context/Delete/Request/FormValidRequestHandlerSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/Doctrine/Admin/Context/Delete/Request/FormValidRequestHandlerSpec.php
@@ -40,15 +40,23 @@ class FormValidRequestHandlerSpec extends ObjectBehavior
             )->during('handleRequest', array($listEvent, $request));
     }
 
-    function it_do_nothing_if_request_has_no_confirm(
+    function it_redirect_if_no_confirm(
         FormEvent $event,
         Request $request,
-        ParameterBag $requestParameterBag
+        ParameterBag $requestParameterBag,
+        CRUDElement $element,
+        Router $router
     ) {
         $request->request = $requestParameterBag;
         $requestParameterBag->has('confirm')->willReturn(false);
+        $requestParameterBag->has('cancel')->willReturn(true);
 
-        $this->handleRequest($event, $request)->shouldReturn(null);
+        $event->getElement()->willReturn($element);
+        $element->getId()->willReturn(1);
+        $router->generate('fsi_admin_crud_list', array('element' => 1))->willReturn('/list/page');
+
+        $this->handleRequest($event, $request)
+            ->shouldReturnAnInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse');
     }
 
     function it_should_throw_exception_when_there_are_no_indexes_in_request(


### PR DESCRIPTION
when user click cancel on delete confirmation page it constantly sees that confirmation without any action. This pull move user to list after clicking cancel. I don't know if this is perfect solution.
