### PR TITLE
fix compile error in resource repository element interface

### DIFF
--- a/Admin/ResourceRepository/Element.php
+++ b/Admin/ResourceRepository/Element.php
@@ -9,7 +9,7 @@
 
 namespace FSi\Bundle\AdminBundle\Admin\ResourceRepository;
 
-use FSi\Bundle\ResourceRepositoryBundle\Model\ResourceInterface;
+use FSi\Bundle\ResourceRepositoryBundle\Model\ResourceInterface as ModelResourceInterface;
 use FSi\Bundle\ResourceRepositoryBundle\Model\ResourceValueRepository;
 
 interface Element
@@ -25,9 +25,9 @@ interface Element
     public function getResourceFormOptions();
 
     /**
-     * @param ResourceInterface $resource
+     * @param ModelResourceInterface $resource
      */
-    public function save(ResourceInterface $resource);
+    public function save(ModelResourceInterface $resource);
 
     /**
      * @return ResourceValueRepository

--- a/Admin/ResourceRepository/GenericResourceElement.php
+++ b/Admin/ResourceRepository/GenericResourceElement.php
@@ -10,7 +10,6 @@
 namespace FSi\Bundle\AdminBundle\Admin\ResourceRepository;
 
 use FSi\Bundle\AdminBundle\Admin\AbstractElement;
-use FSi\Bundle\ResourceRepositoryBundle\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 abstract class GenericResourceElement extends AbstractElement implements Element


### PR DESCRIPTION
In namespace `FSi\Bundle\AdminBundle\Admin` there was already interface `ElementInterface` and it cannot be used in use statement.

Beer for one who tell why phpspec for file `FSi\Bundle\AdminBundle\Admin\ResourceRepository\AbstractResource` pass
