### PR TITLE
Add explicit ParamConverter annotations

### DIFF
--- a/Controller/BatchController.php
+++ b/Controller/BatchController.php
@@ -12,6 +12,7 @@ namespace FSi\Bundle\AdminBundle\Controller;
 use FSi\Bundle\AdminBundle\Admin\Context\ContextManager;
 use FSi\Bundle\AdminBundle\Admin\CRUD\BatchElement;
 use FSi\Bundle\AdminBundle\Exception\ContextException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -33,6 +34,7 @@ class BatchController
     }
 
     /**
+     * @ParamConverter("element", class="\FSi\Bundle\AdminBundle\Admin\CRUD\BatchElement")
      * @param \FSi\Bundle\AdminBundle\Admin\CRUD\BatchElement $element
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response

--- a/Controller/DisplayController.php
+++ b/Controller/DisplayController.php
@@ -11,6 +11,7 @@ namespace FSi\Bundle\AdminBundle\Controller;
 
 use FSi\Bundle\AdminBundle\Admin\Context\ContextManager;
 use FSi\Bundle\AdminBundle\Admin\Display;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -38,6 +39,7 @@ class DisplayController
     }
 
     /**
+     * @ParamConverter("element", class="\FSi\Bundle\AdminBundle\Admin\Display\Element")
      * @param \FSi\Bundle\AdminBundle\Admin\Display\Element $element
      * @param Request $request
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException

--- a/Controller/FormController.php
+++ b/Controller/FormController.php
@@ -11,6 +11,7 @@ namespace FSi\Bundle\AdminBundle\Controller;
 
 use FSi\Bundle\AdminBundle\Admin\Context\ContextManager;
 use FSi\Bundle\AdminBundle\Admin\CRUD\FormElement;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -33,6 +34,7 @@ class FormController
     }
 
     /**
+     * @ParamConverter("element", class="\FSi\Bundle\AdminBundle\Admin\CRUD\FormElement")
      * @param \FSi\Bundle\AdminBundle\Admin\CRUD\FormElement $element
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response

--- a/Controller/ListController.php
+++ b/Controller/ListController.php
@@ -11,6 +11,7 @@ namespace FSi\Bundle\AdminBundle\Controller;
 
 use FSi\Bundle\AdminBundle\Admin\Context\ContextManager;
 use FSi\Bundle\AdminBundle\Admin\CRUD\ListElement;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -48,6 +49,7 @@ class ListController
     }
 
     /**
+     * @ParamConverter("element", class="\FSi\Bundle\AdminBundle\Admin\CRUD\ListElement")
      * @param \FSi\Bundle\AdminBundle\Admin\CRUD\ListElement $element
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -11,6 +11,7 @@ namespace FSi\Bundle\AdminBundle\Controller;
 
 use FSi\Bundle\AdminBundle\Admin\Context\ContextManager;
 use FSi\Bundle\AdminBundle\Admin\ResourceRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -41,6 +42,7 @@ class ResourceController
     }
 
     /**
+     * @ParamConverter("element", class="\FSi\Bundle\AdminBundle\Admin\ResourceRepository\Element")
      * @param \FSi\Bundle\AdminBundle\Admin\ResourceRepository\Element $element
      * @param Request $request
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException


### PR DESCRIPTION
Currently the AdminBundle has a undefined/undocumented dependency on the `sensio_framework_extra:request:auto_convert` configuration option that must be set to `true`.

This PR adds the `ParamConverter` annotation to the controller actions to redeem this dependency.
