### PR TITLE
Allow to specify translation domain for batch actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,29 +18,32 @@ sudo: false
 matrix:
   allow_failures:
     - env: SYMFONY_VERSION=dev-master
+    - env: SYMFONY_VERSION=2.8.*@dev
     - php: hhvm
   exclude:
     - env: SYMFONY_VERSION=dev-master
       php: 5.4
+    - env: SYMFONY_VERSION=2.6.*
+      php: 7.0
 
 before_install:
     - composer self-update
     - composer require symfony/symfony:${SYMFONY_VERSION} -n --prefer-source
 
 install:
-    - wget http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.2.jar
+    - wget http://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.1.jar
 
 before_script:
     - nohup php -S localhost:8080 -t features/fixtures/project/web > server.log 2>&1 &
     - sh -e /etc/init.d/xvfb start
     - export DISPLAY=:99.0
-    - java -jar selenium-server-standalone-2.42.2.jar > /dev/null &
+    - java -jar selenium-server-standalone-2.47.1.jar > /dev/null &
     - sleep 5
     - features/fixtures/project/app/console assets:install features/fixtures/project/web --relative --symlink
 
 script:
     - ./bin/phpspec run -v
-    - ./bin/behat --no-snippets --verbose --format=progress --profile=travis -vvv
+    - ./bin/behat --no-snippets --verbose --format=progress --profile=travis -v
 
 after_failure:
     - cat server.log

--- a/Behat/Context/CRUDContext.php
+++ b/Behat/Context/CRUDContext.php
@@ -11,9 +11,11 @@ namespace FSi\Bundle\AdminBundle\Behat\Context;
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\NodeElement;
 use Behat\Symfony2Extension\Context\KernelAwareContext;
 use Faker\Factory;
 use FSi\Bundle\AdminBundle\Admin\CRUD\ListElement;
+use FSi\Bundle\AdminBundle\Behat\Context\Page\NewsList;
 use PhpSpec\Exception\Example\PendingException;
 use SensioLabs\Behat\PageObjectExtension\Context\PageObjectContext;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -526,9 +528,14 @@ class CRUDContext extends PageObjectContext implements KernelAwareContext
      */
     public function iClickXAtPopover()
     {
-        $popover = $this->getPage('News list')->getPopover();
-        $popover->find('css', 'a.editable-close')->click();
-        $this->getPage('News list')->getSession()->wait(1000);
+        /** @var NewsList $page */
+        $page = $this->getPage('News list');
+        $session = $page->getSession();
+        /** @var NodeElement $popover */
+        $session->wait(1000, 'jQuery(".popover").length > 0');
+        $popover = $page->getPopover();
+        $popover->find('css', '.editable-close')->click();
+        $session->wait(1000, 'jQuery(".popover").length === 0');
     }
 
     /**

--- a/Behat/Context/Page/NewsEdit.php
+++ b/Behat/Context/Page/NewsEdit.php
@@ -14,10 +14,17 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageExce
 class NewsEdit extends Page
 {
     protected $path = '/admin/form/news/{id}';
+    protected $elements = array(
+        'page header' => '#page-header',
+    );
 
     public function getHeader()
     {
-        return $this->find('css', '#page-header')->getText();
+        if (!$this->hasElement('page header')) {
+            throw new \Exception('Unable to find page header');
+        }
+
+        return $this->getElement('page header')->getText();
     }
 
     protected function verifyPage()

--- a/Behat/Context/Page/NewsList.php
+++ b/Behat/Context/Page/NewsList.php
@@ -9,7 +9,7 @@
 
 namespace FSi\Bundle\AdminBundle\Behat\Context\Page;
 
-use Behat\Behat\Exception\BehaviorException;
+use Behat\Mink\Element\NodeElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
 
 class NewsList extends Page
@@ -63,6 +63,7 @@ class NewsList extends Page
     {
         $headers = $this->findAll('css', 'th');
         foreach ($headers as $index => $header) {
+            /** @var NodeElement $header */
             if ($header->has('css', 'span')) {
                 if ($header->find('css', 'span')->getText() == $columnHeader) {
                     return $index + 1;
@@ -81,7 +82,7 @@ class NewsList extends Page
 
     public function getPopover()
     {
-        return $this->find('css', 'div.popover');
+        return $this->find('css', '.popover');
     }
 
     protected function verifyPage()

--- a/DataGrid/Extension/Admin/ColumnTypeExtension/BatchActionExtension.php
+++ b/DataGrid/Extension/Admin/ColumnTypeExtension/BatchActionExtension.php
@@ -41,7 +41,10 @@ class BatchActionExtension extends ColumnAbstractTypeExtension
     protected $actionOptionsResolver;
 
     /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $formBuilder
+     * @param Manager $manager
+     * @param RequestStack $requestStack
+     * @param RouterInterface $router
+     * @param FormBuilderInterface $formBuilder
      */
     public function __construct(
         Manager $manager,
@@ -69,13 +72,18 @@ class BatchActionExtension extends ColumnAbstractTypeExtension
      */
     public function initOptions(ColumnTypeInterface $column)
     {
-        $column->getOptionsResolver()->setDefaults(array('actions' => array()));
+        $column->getOptionsResolver()->setDefaults(array(
+            'actions' => array(),
+            'translation_domain' => 'FSiAdminBundle'
+        ));
         $column->getOptionsResolver()->setAllowedTypes('actions', array('array', 'null'));
+        $column->getOptionsResolver()->setAllowedTypes('translation_domain', array('string'));
     }
 
     public function buildHeaderView(ColumnTypeInterface $column, HeaderViewInterface $view)
     {
         $this->buildBatchForm(
+            $column,
             $this->buildBatchActions($column)
         );
 
@@ -142,14 +150,15 @@ class BatchActionExtension extends ColumnAbstractTypeExtension
     }
 
     /**
+     * @param ColumnTypeInterface $column
      * @param array $batchActions
      */
-    private function buildBatchForm(array $batchActions)
+    private function buildBatchForm(ColumnTypeInterface $column, array $batchActions)
     {
         if (count($batchActions) > 1) {
             $this->formBuilder->add('action', 'choice', array(
                 'choices' => $batchActions,
-                'translation_domain' => 'FSiAdminBundle'
+                'translation_domain' => $column->getOption('translation_domain')
             ));
             $this->formBuilder->add('submit', 'submit', array(
                 'label' => 'crud.list.batch.confirm',

--- a/spec/FSi/Bundle/AdminBundle/DataGrid/Extension/Admin/ColumnTypeExtension/BatchActionExtensionSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/DataGrid/Extension/Admin/ColumnTypeExtension/BatchActionExtensionSpec.php
@@ -45,8 +45,10 @@ class BatchActionExtensionSpec extends ObjectBehavior
     {
         $column->getOptionsResolver()->willReturn($optionsResolver);
 
-        $optionsResolver->setDefaults(array('actions' => array()))->shouldBeCalled();
+        $optionsResolver->setDefaults(array('actions' => array(), 'translation_domain' => 'FSiAdminBundle'))
+            ->shouldBeCalled();
         $optionsResolver->setAllowedTypes('actions', array('array', 'null'))->shouldBeCalled();
+        $optionsResolver->setAllowedTypes('translation_domain', array('string'))->shouldBeCalled();
 
         $this->initOptions($column);
     }
@@ -133,6 +135,9 @@ class BatchActionExtensionSpec extends ObjectBehavior
                 'label' => 'batch_action_label'
             )
         ));
+
+        $column->getOption('translation_domain')->willReturn('FSiAdminBundle');
+
         $manager->hasElement('some_batch_element_id')->willReturn(true);
         $manager->getElement('some_batch_element_id')->willReturn($batchElement);
         $batchElement->getId()->willReturn('some_batch_element_id');
@@ -157,6 +162,7 @@ class BatchActionExtensionSpec extends ObjectBehavior
             ),
             'translation_domain' => 'FSiAdminBundle'
         ))->willReturn();
+
         $formBuilder->add('submit', 'submit', array(
             'label' => 'crud.list.batch.confirm',
             'translation_domain' => 'FSiAdminBundle'
@@ -196,6 +202,9 @@ class BatchActionExtensionSpec extends ObjectBehavior
                 'label' => 'batch_action_label'
             )
         ));
+
+        $column->getOption('translation_domain')->willReturn('FSiAdminBundle');
+
         $manager->hasElement('some_batch_element_id')->willReturn(true);
         $manager->getElement('some_batch_element_id')->willReturn($batchElement);
         $batchElement->getId()->willReturn('some_batch_element_id');
@@ -252,6 +261,9 @@ class BatchActionExtensionSpec extends ObjectBehavior
                 'additional_parameters' => array('element' => 'some_batch_element_id', 'param' => 'value')
             )
         ));
+
+        $column->getOption('translation_domain')->willReturn('FSiAdminBundle');
+
         $queryAttributes->has('redirect_uri')->willReturn(true);
         $queryAttributes->get('redirect_uri')->willReturn('some_redirect_uri');
 


### PR DESCRIPTION
datagrid_definition.yml:
```yml
columns:
  batch:
    type: batch
    options:
      translation_domain: FSiAdminSecurity
      actions:
        delete:
          route_name: fsi_admin_batch
          additional_parameters: { element: admin_user }
```