### PR TITLE
Fixed editable datagrid cell popover, made inactive collection buttons disabled

### DIFF
--- a/Behat/Context/AdminContext.php
+++ b/Behat/Context/AdminContext.php
@@ -232,6 +232,16 @@ class AdminContext extends PageObjectContext implements KernelAwareContext
     }
 
     /**
+     * @Transform /"([^"]*)" non-editable collection/
+     * @Transform /non-editable collection "([^"]*)"/
+     */
+    public function transformToNoneditableCollection($collectionNames)
+    {
+        return $this->getPage('Page')->getNoneditableCollection($collectionNames);
+    }
+
+
+    /**
      * @Transform /^"([^"]*)" collection/
      * @Transform /collection "([^"]*)"/
      */
@@ -239,9 +249,9 @@ class AdminContext extends PageObjectContext implements KernelAwareContext
     {
         return $this->getPage('Page')->getCollection($collectionNames);
     }
-
     /**
      * @Given /^("[^"]*" collection) should have (\d+) elements$/
+     * @Given /^(non-editable collection "[^"]*") should have (\d+) elements$/
      */
     public function collectionShouldHaveElements(NodeElement $collection, $elementsCount)
     {
@@ -256,6 +266,24 @@ class AdminContext extends PageObjectContext implements KernelAwareContext
     {
         expect($collection->findButton($buttonName))->toNotBeNull();
     }
+
+    /**
+     * @Then /^all buttons for adding and removing items in (non-editable collection "[^"]*") should be disabled$/
+     */
+    public function allCollectionButtonsDisabled(NodeElement $collection)
+    {
+        $removeButtons = $collection->findAll('css', '.collection-remove');
+        expect(count($removeButtons))->notToBe(0);
+        foreach ($removeButtons as $removeButton) {
+            expect($removeButton->hasClass('disabled'))->toBe(true);
+        }
+        $addButtons = $collection->findAll('css', '.collection-add');
+        expect(count($addButtons))->notToBe(0);
+        foreach ($addButtons as $addButton) {
+            expect($addButton->hasClass('disabled'))->toBe(true);
+        }
+    }
+
 
     /**
      * @When /^I press "([^"]*)" in (collection "[^"]*")$/

--- a/Behat/Context/Page/Page.php
+++ b/Behat/Context/Page/Page.php
@@ -17,4 +17,9 @@ class Page extends BasePage
     {
         return $this->find('xpath', sprintf('//div[@data-prototype]/ancestor::*[@class = "form-group"]/label[text() = "%s"]/..//div[@data-prototype]', $label));
     }
+
+    public function getNoneditableCollection($label)
+    {
+        return $this->find('xpath', sprintf('//div[@data-prototype-name]/ancestor::*[@class = "form-group"]/label[text() = "%s"]/..//div[@data-prototype-name]', $label));
+    }
 }

--- a/Resources/views/CRUD/datagrid_edit_form.html.twig
+++ b/Resources/views/CRUD/datagrid_edit_form.html.twig
@@ -1,7 +1,7 @@
 {% extends admin_templates_form_theme %}
 
 {% block form_label_class %}
-    sr-only
+    {{ form.parent | length > 1 ? 'col-sm-12' : 'sr-only' }}
 {% endblock form_label_class %}
 
 {% block form_group_class %}
@@ -11,3 +11,25 @@
 {% block row_row %}
     {{ form_widget(form) }}
 {% endblock row_row %}
+
+{% block collection_widget %}
+    <div {{ block('widget_container_attributes') }}>
+        {%- if form.parent is empty -%}
+            {{ form_errors(form) }}
+        {%- endif -%}
+        {% set collection = form %}
+        {% for form in collection %}
+            {{ block('collection_item') }}
+        {% endfor %}
+        {{- form_rest(form) -}}
+    </div>
+{% endblock %}
+
+{% block collection_item %}
+    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+        <div class="col-sm-12">
+            {{ form_widget(form) }}
+            {{ form_errors(form) }}
+        </div>
+    </div>
+{% endblock %}

--- a/Resources/views/Form/form_theme.html.twig
+++ b/Resources/views/Form/form_theme.html.twig
@@ -15,7 +15,7 @@
             {% endfor %}
             {{- form_rest(form) -}}
         </div>
-        <a class="btn btn-success collection-add" title="{{ 'crud.form.collection.add'|trans({}, 'FSiAdminBundle') }}"><i class="glyphicon glyphicon-plus"></i></a>
+        <a class="{{ attr['data-allow-add'] ? '' : 'disabled ' }}btn btn-success collection-add" title="{{ 'crud.form.collection.add'|trans({}, 'FSiAdminBundle') }}"><i class="glyphicon glyphicon-plus"></i></a>
     </div>
 {% endblock %}
 
@@ -33,7 +33,7 @@
             {{ form_errors(form) }}
         </div>
         <div class="col-sm-1">
-            <a class="pull-right btn btn-danger collection-remove" title="{{ 'crud.form.collection.remove'|trans({}, 'FSiAdminBundle') }}"><i class="glyphicon glyphicon-trash"></i></a>
+            <a class="{{ attr['data-allow-delete'] ? '' : 'disabled ' }}pull-right btn btn-danger collection-remove" title="{{ 'crud.form.collection.remove'|trans({}, 'FSiAdminBundle') }}"><i class="glyphicon glyphicon-trash"></i></a>
         </div>
     </div>
 {% endblock %}

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -18,6 +18,7 @@
             .table-datagrid a.editable {visibility: hidden;}
             .table-datagrid td:hover a.editable {visibility: visible;}
             .table-datagrid a.editable-close {margin: 5px;}
+            .table-datagrid .datagrid-cell .popover {min-width: 500px; max-width: 550px;}
         </style>
     {% endblock %}
     <script src="{{ asset('bundles/fsiadmin/js/require.js') }}" type="text/javascript"></script>

--- a/features/fixtures/project/.gitignore
+++ b/features/fixtures/project/.gitignore
@@ -2,3 +2,4 @@
 /app/cache
 /app/logs
 /web/bundles
+/web/uploaded/*

--- a/features/fixtures/project/app/Resources/translations/messages.en.yml
+++ b/features/fixtures/project/app/Resources/translations/messages.en.yml
@@ -14,6 +14,7 @@ admin:
       creator_email: Creator email
       tags: Tags
       tag_elements: Elements
+      non_editable_tags: Non-editable tags
       actions: Actions
   subscriber:
     name: Subscribers

--- a/features/fixtures/project/src/FSi/FixturesBundle/Admin/News.php
+++ b/features/fixtures/project/src/FSi/FixturesBundle/Admin/News.php
@@ -2,9 +2,11 @@
 
 namespace FSi\FixturesBundle\Admin;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use FSi\Bundle\AdminBundle\Doctrine\Admin\CRUDElement;
 use FSi\Component\DataGrid\DataGridFactoryInterface;
 use FSi\Component\DataSource\DataSourceFactoryInterface;
+use FSi\FixturesBundle\Entity\News as NewsEntity;
 use FSi\FixturesBundle\Form\TagType;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -26,6 +28,8 @@ class News extends CRUDElement
         $datagrid = $factory->createDataGrid('news');
         $datagrid->addColumn('title', 'text', array(
             'label' => 'admin.news.list.title',
+            'field_mapping' => array('title', 'subtitle'),
+            'value_glue' => '<br/>',
             'editable' => true
         ));
         $datagrid->addColumn('date', 'datetime', array(
@@ -143,6 +147,15 @@ class News extends CRUDElement
             'allow_add' => true,
             'allow_delete' => true,
             'by_reference' => false,
+        ));
+        $builder->add('nonEditableTags', 'collection', array(
+            'type' => 'text',
+            'data' => new ArrayCollection(['Tag 1', 'Tag 2', 'Tag 3']),
+            'label' => 'admin.news.list.non_editable_tags',
+            'allow_add' => false,
+            'allow_delete' => false,
+            'mapped' => false,
+            'required' => false
         ));
 
         return $builder->getForm();

--- a/features/fixtures/project/src/FSi/FixturesBundle/Entity/News.php
+++ b/features/fixtures/project/src/FSi/FixturesBundle/Entity/News.php
@@ -27,6 +27,11 @@ class News
     protected $title;
 
     /**
+     * @ORM\Column(type="string", length=100, nullable=true)
+     */
+    protected $subtitle;
+
+    /**
      * @ORM\Column(type="date", nullable=true)
      */
     protected $date;
@@ -141,6 +146,22 @@ class News
     public function getTitle()
     {
         return $this->title;
+    }
+
+    /**
+     * @param mixed $subtitle
+     */
+    public function setSubtitle($subtitle)
+    {
+        $this->subtitle = $subtitle;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSubtitle()
+    {
+        return $this->subtitle;
     }
 
     /**

--- a/features/form/collections.feature
+++ b/features/form/collections.feature
@@ -61,3 +61,13 @@ Feature: Managing form collections
     """
     Data has been successfully saved.
     """
+
+  @javascript
+  Scenario: disabled buttons in collections not allowing adding or deleting items
+    And there is 1 news in database
+    And I am on the "Admin panel" page
+    And I follow "News" menu element
+    When I press "Edit" link in "Action" column of first element at list
+    And I should see "News Edit" page header "Edit element"
+    And non-editable collection "Non-editable tags" should have 3 elements
+    Then all buttons for adding and removing items in non-editable collection "Non-editable tags" should be disabled


### PR DESCRIPTION
Resolves #220 and #221. Also made the popover wider