### PR TITLE
Extracted flash messages into a seperate template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
         - php: 7.0
 
 before_install:
+    - phpenv config-rm xdebug.ini
     - composer self-update
     - if [[ "$DEPENDENCIES" != "low" && ! $SYMFONY_VERSION ]]; then composer update; fi;
     - if [[ "$DEPENDENCIES" != "low" && $SYMFONY_VERSION ]]; then composer require symfony/symfony:${SYMFONY_VERSION} -n --prefer-source; fi;

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{% block head_title %}{{ 'admin.title'|trans({}, 'FSiAdminBundle')  }}{% endblock %}</title>
+    <title>{% block head_title 'admin.title'|trans({}, 'FSiAdminBundle') %}</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex"/>
@@ -57,18 +57,7 @@
 <div class="container">
     <div class="row">
         <div class="col-lg-12">
-        {% block messages %}
-            <div id="messages">
-                {% set typeClass = {success: 'success', warning: 'warning', error: 'danger', info: 'info'} %}
-                {% for type,typeMessages in fsi_admin_messages() %}
-                    {% for message in typeMessages %}
-                        <div class="alert alert-{{ typeClass[type] }}">
-                            {{ (message.text)|trans({}, message.domain) }}
-                        </div>
-                    {% endfor %}
-                {% endfor %}
-            </div>
-        {% endblock %}
+        {% block messages %}{% include '@FSiAdmin/flash_messages.html.twig' %}{% endblock %}
         {% block above_content %}{% endblock above_content %}
         {% block content %}{% endblock content %}
         {% block under_content %}{% endblock under_content %}

--- a/Resources/views/flash_messages.html.twig
+++ b/Resources/views/flash_messages.html.twig
@@ -1,0 +1,10 @@
+<div id="messages">
+    {%- set typeClass = {success: 'success', warning: 'warning', error: 'danger', info: 'info'} -%}
+    {% for type, typeMessages in fsi_admin_messages() %}
+        {% for message in typeMessages %}
+            <div class="alert alert-{{ typeClass[type] }}">
+                {{ (message.text)|trans({}, message.domain) }}
+            </div>
+        {% endfor %}
+    {% endfor %}
+</div>

--- a/Twig/MessageTwigExtension.php
+++ b/Twig/MessageTwigExtension.php
@@ -10,8 +10,10 @@
 namespace FSi\Bundle\AdminBundle\Twig;
 
 use FSi\Bundle\AdminBundle\Message\FlashMessages;
+use Twig_Extension;
+use Twig_SimpleFunction;
 
-class MessageTwigExtension extends \Twig_Extension
+class MessageTwigExtension extends Twig_Extension
 {
     /**
      * @var FlashMessages
@@ -19,7 +21,7 @@ class MessageTwigExtension extends \Twig_Extension
     private $flashMessages;
 
     /**
-     * MessageTwigExtension constructor.
+     * @param FlashMessages $flashMessages
      */
     public function __construct(FlashMessages $flashMessages)
     {
@@ -29,7 +31,7 @@ class MessageTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('fsi_admin_messages', [$this, 'getMessages']),
+            new Twig_SimpleFunction('fsi_admin_messages', [$this, 'getMessages']),
         ];
     }
 


### PR DESCRIPTION
With this structure the flash messages can be reused in other places of the project. If someone does not wish to use our structure, he can override the `messages` block completely. 