### PR TITLE
fix admin elements pass - multiple instances of same service

### DIFF
--- a/DependencyInjection/Compiler/AdminElementPass.php
+++ b/DependencyInjection/Compiler/AdminElementPass.php
@@ -11,6 +11,7 @@ namespace FSi\Bundle\AdminBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Norbert Orzechowicz <norbert@fsi.pl>
@@ -29,7 +30,7 @@ class AdminElementPass implements CompilerPassInterface
         $elements = array();
         $elementServices = $container->findTaggedServiceIds('admin.element');
         foreach ($elementServices as $id => $tag) {
-            $elements[] = $container->findDefinition($id);
+            $elements[] = new Reference($id);
         }
 
         $container->findDefinition('admin.manager.visitor.element_collection')->replaceArgument(0, $elements);


### PR DESCRIPTION
```xml
<service class="Namespace\MyListElement">
    <tag name="admin.element"/>
    <tag name="kernel.event_subscriber"/>
</service>
```

```php
class MyListElement extends ListElement implements EventSubscriberInterface {
    // ...
    public static function getSubscribedEvents() {
        return [ListEvents::LIST_RESPONSE_PRE_RENDER => 'preRender']; //some admin event
    }
    public function preRender(ListEvent $event) {
        if ($event->getElement() !== $this) {
            return;  // <= this will be invoked when accessed MyListElement
        }
    }
}
```

There are 2 instances of `MyListElement`, one in service-container and one in admin manager, should be only 1