### PR TITLE
Remove id in getData in FormElementContext

### DIFF
--- a/Admin/CRUD/Context/FormElementContext.php
+++ b/Admin/CRUD/Context/FormElementContext.php
@@ -50,16 +50,10 @@ class FormElementContext extends ContextAbstract
      */
     public function getData()
     {
-        $data = array(
+        return array(
             'form' => $this->form->createView(),
-            'element' => $this->element
+            'element' => $this->element,
         );
-
-        if ($this->form->getData()) {
-            $data['id'] = $this->element->getDataIndexer()->getIndex($this->form->getData());
-        }
-
-        return $data;
     }
 
     /**

--- a/Behat/Context/Page/DTOForm.php
+++ b/Behat/Context/Page/DTOForm.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\Bundle\AdminBundle\Behat\Context\Page;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
+
+class DTOForm extends Page
+{
+    protected $path = '/admin/form/dto_form';
+
+    public function getHeader()
+    {
+        return $this->find('css', '#page-header')->getText();
+    }
+
+    protected function verifyPage()
+    {
+        if (!$this->has('css', '#page-header:contains("New element")')) {
+            throw new UnexpectedPageException(
+                sprintf("%s page is missing \"New element\" header", $this->path)
+            );
+        }
+    }
+}

--- a/features/fixtures/project/app/Resources/translations/messages.en.yml
+++ b/features/fixtures/project/app/Resources/translations/messages.en.yml
@@ -32,3 +32,4 @@ admin:
       content: Content
   about_us_page:
     name: About us page
+  email: Email

--- a/features/fixtures/project/src/FSi/FixturesBundle/Admin/DTOFormElement.php
+++ b/features/fixtures/project/src/FSi/FixturesBundle/Admin/DTOFormElement.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\FixturesBundle\Admin;
+
+use FSi\Bundle\AdminBundle\Doctrine\Admin\FormElement;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class DTOFormElement extends FormElement
+{
+    public function getClassName()
+    {
+        return 'FSi\FixturesBundle\DTO\Model';
+    }
+
+    public function getId()
+    {
+        return 'dto_form';
+    }
+
+    public function save($object)
+    {
+    }
+
+    protected function initForm(FormFactoryInterface $factory, $data = null)
+    {
+        $builder = $factory->createNamedBuilder('dto_form', 'form', $data, [
+            'data_class' => $this->getClassName()
+        ]);
+        $builder->add('email', 'email', ['label' => 'admin.email']);
+
+        return $builder->getForm();
+    }
+}

--- a/features/fixtures/project/src/FSi/FixturesBundle/DTO/Model.php
+++ b/features/fixtures/project/src/FSi/FixturesBundle/DTO/Model.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\FixturesBundle\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Model
+{
+    /**
+     * @Assert\Email
+     * @Assert\NotBlank
+     */
+    private $email;
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+}

--- a/features/fixtures/project/src/FSi/FixturesBundle/Resources/config/services.xml
+++ b/features/fixtures/project/src/FSi/FixturesBundle/Resources/config/services.xml
@@ -54,6 +54,10 @@
             <tag name="admin.element" />
         </service>
 
+        <service id="fixtures_bundle.admin.dto_form" class="FSi\FixturesBundle\Admin\DTOFormElement">
+            <tag name="admin.element" />
+        </service>
+
         <service id="datasource.factory" class="FSi\FixturesBundle\DataSource\DataSourceFactory">
             <argument type="service" id="datasource.driver.factory.manager"></argument>
             <argument type="collection">

--- a/features/form/form.feature
+++ b/features/form/form.feature
@@ -68,3 +68,13 @@ Feature: Creating new object
     """
     Form is invalid.
     """
+
+  Scenario: Submitting a DTO form element
+    Given I am on the "DTO Form" page
+    When I change form "Email" field value
+    And I press form "Save" button
+    Then I should be redirected to "DTO Form" page
+    And I should see a success message saying:
+    """
+    Data has been successfully saved.
+    """

--- a/spec/FSi/Bundle/AdminBundle/Admin/CRUD/Context/FormElementContextSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/Admin/CRUD/Context/FormElementContextSpec.php
@@ -47,11 +47,6 @@ class FormElementContextSpec extends ObjectBehavior
         $this->getData()->shouldBeArray();
         $this->getData()->shouldHaveKeyInArray('form');
         $this->getData()->shouldHaveKeyInArray('element');
-
-        $form->getData()->willReturn(array('object'));
-        $element->getDataIndexer()->willReturn($dataIndexer);
-        $dataIndexer->getIndex(array('object'))->willReturn('id');
-        $this->getData()->shouldHaveKeyInArray('id');
     }
 
     /**


### PR DESCRIPTION
Resolves #232

Idea of this is that object that form writes to doesn't have to be the same what is fetched from data indexer. We can have a DTO prepared especially for form (or doesn't have it at all and have constraint defined in form type) and implement saving different way to object fetched from indexer. Form data also can be null with valid form. Look at example proposition:

```php
class MyElement extends FormElement
{
   //other methods

   protected function initForm(FormFactoryInterface $factory, $objectFromIndexer = null)
    {
        // create $formDTO somehow or pass $objectFromIndexer or null
        return $factory->create(FormType::class, $formDTO);
    }

    /**
     * $formData is $formDTO created in initForm
     */
    public function save($objectFromIndexer, $formData = null)
    {
        $objectFromIndexer->someImportantMethod($formData->getSomeValidatedDataFromForm());
        //save $objectFromIndexer in some datastore like doctrine
    }
}
```

