### PR TITLE
Inject default templates into contexts, instead of controllers

### DIFF
--- a/Admin/CRUD/Context/CRUDFormElementContext.php
+++ b/Admin/CRUD/Context/CRUDFormElementContext.php
@@ -9,50 +9,16 @@
 
 namespace FSi\Bundle\AdminBundle\Admin\CRUD\Context;
 
-use FSi\Bundle\AdminBundle\Admin\Context\Request\HandlerInterface;
 use FSi\Bundle\AdminBundle\Admin\CRUD\CRUDElement;
 use FSi\Bundle\AdminBundle\Admin\Element;
 
 class CRUDFormElementContext extends FormElementContext
 {
     /**
-     * @var string
-     */
-    private $formTemplate;
-
-    /**
-     * @param HandlerInterface[]|array $requestHandlers
-     * @param string $formTemplate
-     */
-    public function __construct(array $requestHandlers, $formTemplate)
-    {
-        parent::__construct($requestHandlers);
-
-        $this->formTemplate = $formTemplate;
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function supportsElement(Element $element)
     {
         return $element instanceof CRUDElement;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTemplateName()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTemplateName()
-    {
-        return $this->element->hasOption('template_form') ?
-            $this->element->getOption('template_form') : $this->formTemplate;
     }
 }

--- a/Admin/CRUD/Context/CRUDListElementContext.php
+++ b/Admin/CRUD/Context/CRUDListElementContext.php
@@ -9,50 +9,16 @@
 
 namespace FSi\Bundle\AdminBundle\Admin\CRUD\Context;
 
-use FSi\Bundle\AdminBundle\Admin\Context\Request\HandlerInterface;
 use FSi\Bundle\AdminBundle\Admin\CRUD\CRUDElement;
 use FSi\Bundle\AdminBundle\Admin\Element;
 
 class CRUDListElementContext extends ListElementContext
 {
     /**
-     * @var string
-     */
-    private $listTemplate;
-
-    /**
-     * @param HandlerInterface[]|array $requestHandlers
-     * @param string $listTemplate
-     */
-    public function __construct(array $requestHandlers, $listTemplate)
-    {
-        parent::__construct($requestHandlers);
-
-        $this->listTemplate = $listTemplate;
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function supportsElement(Element $element)
     {
         return $element instanceof CRUDElement;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTemplateName()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTemplateName()
-    {
-        return $this->element->hasOption('template_list') ?
-            $this->element->getOption('template_list') : $this->listTemplate;
     }
 }

--- a/Admin/CRUD/Context/FormElementContext.php
+++ b/Admin/CRUD/Context/FormElementContext.php
@@ -34,7 +34,7 @@ class FormElementContext extends ContextAbstract
      */
     public function hasTemplateName()
     {
-        return $this->element->hasOption('template_form');
+        return $this->element->hasOption('template_form') || parent::hasTemplateName();
     }
 
     /**
@@ -42,7 +42,10 @@ class FormElementContext extends ContextAbstract
      */
     public function getTemplateName()
     {
-        return $this->element->getOption('template_form');
+        return $this->element->hasOption('template_form')
+            ? $this->element->getOption('template_form')
+            : parent::getTemplateName()
+        ;
     }
 
     /**

--- a/Admin/CRUD/Context/ListElementContext.php
+++ b/Admin/CRUD/Context/ListElementContext.php
@@ -49,7 +49,7 @@ class ListElementContext extends ContextAbstract
      */
     public function hasTemplateName()
     {
-        return $this->element->hasOption('template_list');
+        return $this->element->hasOption('template_list') || parent::hasTemplateName();
     }
 
     /**
@@ -57,7 +57,10 @@ class ListElementContext extends ContextAbstract
      */
     public function getTemplateName()
     {
-        return $this->element->getOption('template_list');
+        return $this->element->hasOption('template_list')
+            ? $this->element->getOption('template_list')
+            : parent::getTemplateName()
+        ;
     }
 
     /**

--- a/Admin/Context/ContextAbstract.php
+++ b/Admin/Context/ContextAbstract.php
@@ -22,11 +22,18 @@ abstract class ContextAbstract implements ContextInterface
     private $requestHandlers;
 
     /**
-     * @param HandlerInterface[]|array $requestHandlers
+     * @var string
      */
-    public function __construct(array $requestHandlers)
+    private $template;
+
+    /**
+     * @param HandlerInterface[]|array $requestHandlers
+     * @param string|null
+     */
+    public function __construct(array $requestHandlers, $template = null)
     {
         $this->requestHandlers = $requestHandlers;
+        $this->template = $template;
     }
 
     /**
@@ -56,12 +63,9 @@ abstract class ContextAbstract implements ContextInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasTemplateName()
     {
-        return false;
+        return !empty($this->template);
     }
 
     /**
@@ -69,7 +73,7 @@ abstract class ContextAbstract implements ContextInterface
      */
     public function getTemplateName()
     {
-        return null;
+        return $this->template;
     }
 
     /**

--- a/Admin/Display/Context/DisplayContext.php
+++ b/Admin/Display/Context/DisplayContext.php
@@ -33,7 +33,7 @@ class DisplayContext extends ContextAbstract
      */
     public function hasTemplateName()
     {
-        return $this->element->hasOption('template');
+        return $this->element->hasOption('template') || parent::hasTemplateName();
     }
 
     /**
@@ -41,7 +41,10 @@ class DisplayContext extends ContextAbstract
      */
     public function getTemplateName()
     {
-        return $this->element->getOption('template');
+        return $this->element->hasOption('template')
+            ? $this->element->getOption('template')
+            : parent::getTemplateName()
+        ;
     }
 
     /**

--- a/Admin/ResourceRepository/Context/ResourceRepositoryContext.php
+++ b/Admin/ResourceRepository/Context/ResourceRepositoryContext.php
@@ -37,11 +37,15 @@ class ResourceRepositoryContext extends ContextAbstract
 
     /**
      * @param HandlerInterface[]|$requestHandlers
+     * @param string $template
      * @param ResourceFormBuilder $resourceFormBuilder
      */
-    public function __construct($requestHandlers, ResourceFormBuilder $resourceFormBuilder)
-    {
-        parent::__construct($requestHandlers);
+    public function __construct(
+        array $requestHandlers,
+        $template,
+        ResourceFormBuilder $resourceFormBuilder
+    ) {
+        parent::__construct($requestHandlers, $template);
 
         $this->resourceFormBuilder = $resourceFormBuilder;
     }
@@ -60,7 +64,7 @@ class ResourceRepositoryContext extends ContextAbstract
      */
     public function hasTemplateName()
     {
-        return $this->element->hasOption('template');
+        return $this->element->hasOption('template') || parent::hasTemplateName();
     }
 
     /**
@@ -68,7 +72,10 @@ class ResourceRepositoryContext extends ContextAbstract
      */
     public function getTemplateName()
     {
-        return $this->element->getOption('template');
+        return $this->element->hasOption('template')
+            ? $this->element->getOption('template')
+            : parent::getTemplateName()
+        ;
     }
 
     /**

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -92,3 +92,13 @@ Now it is removed.
 passed into it's constructor instead through the `setEventDispatcher` method. Due to
 this change, the [compiler pass](DependencyInjection/Compiler/SetEventDispatcherPass.php)
 became redundant and was removed.
+
+## Default response templates are injected into contexts
+
+Previously default response templates were injected into controllers and could have
+been overwritten by a value returned by the context handling the element. This
+behaviour split the responsibilty of providing the template name between two 
+classes, which caused inconsitency and was problematic, since controllers can
+handle vastly different elements. Now all contexts are required to provide a template
+name, assuming their action returns an HTML response. For example Batch actions
+will return a redirect response, so there is no point for them to provide one.

--- a/Controller/ControllerAbstract.php
+++ b/Controller/ControllerAbstract.php
@@ -34,11 +34,6 @@ abstract class ControllerAbstract
     protected $contextManager;
 
     /**
-     * @var string
-     */
-    protected $template;
-
-    /**
      * @var EventDispatcherInterface
      */
     private $eventDispatcher;
@@ -47,18 +42,15 @@ abstract class ControllerAbstract
      * @param \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface $templating
      * @param \FSi\Bundle\AdminBundle\Admin\Context\ContextManager $contextManager
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-     * @param string|null $resourceActionTemplate
      */
     public function __construct(
         EngineInterface $templating,
         ContextManager $contextManager,
-        EventDispatcherInterface $eventDispatcher,
-        $resourceActionTemplate = null
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->templating = $templating;
         $this->contextManager = $contextManager;
         $this->eventDispatcher = $eventDispatcher;
-        $this->template = $resourceActionTemplate;
     }
 
     /**
@@ -74,7 +66,6 @@ abstract class ControllerAbstract
         if ($event->hasResponse()) {
             return $event->getResponse();
         }
-
         $context = $this->contextManager->createContext($route, $element);
         if (!($context instanceof ContextInterface)) {
             throw new NotFoundHttpException(sprintf(
@@ -88,16 +79,16 @@ abstract class ControllerAbstract
             return $response;
         }
 
-        if (!isset($this->template) && !$context->hasTemplateName()) {
+        if (!$context->hasTemplateName()) {
             throw new ContextException(sprintf(
-                "Context %s did not return any response and controller %s has no template",
+                "Context %s neither returned a response nor has a template name",
                 get_class($context),
                 __CLASS__
             ));
         }
 
         return $this->templating->renderResponse(
-            $context->hasTemplateName() ? $context->getTemplateName() : $this->template,
+            $context->getTemplateName(),
             $context->getData()
         );
     }

--- a/Resources/config/context/display.xml
+++ b/Resources/config/context/display.xml
@@ -14,6 +14,7 @@
             <argument type="collection">
                 <argument type="service" id="admin.context.display.request_handler"/>
             </argument>
+            <argument>%admin.templates.display%</argument>
             <tag name="admin.context" />
         </service>
 

--- a/Resources/config/context/form.xml
+++ b/Resources/config/context/form.xml
@@ -26,6 +26,7 @@
                 <argument type="service" id="admin.context.form.request_handler.form_submit"/>
                 <argument type="service" id="admin.context.form.request_handler.form_valid_request"/>
             </argument>
+            <argument type="string">%admin.templates.form%</argument>
             <tag name="admin.context" />
         </service>
 

--- a/Resources/config/context/list.xml
+++ b/Resources/config/context/list.xml
@@ -30,6 +30,7 @@
                 <argument type="service" id="admin.context.list.request_handler.datagrid_set_data"/>
                 <argument type="service" id="admin.context.list.request_handler.datagrid_bind_data"/>
             </argument>
+            <argument>%admin.templates.list%</argument>
             <argument type="service" id="form.factory" />
             <tag name="admin.context" />
         </service>
@@ -38,10 +39,12 @@
                 class="%admin.context.list.request_handler.datasource_bind_parameters.class%">
             <argument type="service" id="event_dispatcher" />
         </service>
+
         <service id="admin.context.list.request_handler.datagrid_set_data"
                  class="%admin.context.list.request_handler.datagrid_set_data.class%">
             <argument type="service" id="event_dispatcher" />
         </service>
+
         <service id="admin.context.list.request_handler.datagrid_bind_data"
                  class="%admin.context.list.request_handler.datagrid_bind_data.class%">
             <argument type="service" id="event_dispatcher" />

--- a/Resources/config/context/resource.xml
+++ b/Resources/config/context/resource.xml
@@ -22,6 +22,7 @@
                 <argument type="service" id="admin.context.resource.request_handler.form_submit"/>
                 <argument type="service" id="admin.context.resource.request_handler.form_valid_request"/>
             </argument>
+            <argument>%admin.templates.resource%</argument>
             <argument type="service" id="admin.context.resource.form_builder" />
             <tag name="admin.context" />
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -81,23 +81,23 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
 
-        <service id="admin.controller.resource" class="%admin.controller.resource.class%" parent="admin.controller.abstract">
-            <argument>%admin.templates.resource%</argument>
-        </service>
+        <service id="admin.controller.batch" class="%admin.controller.batch.class%" parent="admin.controller.abstract" />
 
         <service id="admin.controller.display" class="%admin.controller.display.class%" parent="admin.controller.abstract">
             <argument>%admin.templates.display%</argument>
-        </service>
-
-        <service id="admin.controller.list" class="%admin.controller.list.class%" parent="admin.controller.abstract">
-            <argument>%admin.templates.list%</argument>
         </service>
 
         <service id="admin.controller.form" class="%admin.controller.form.class%" parent="admin.controller.abstract">
             <argument>%admin.templates.form%</argument>
         </service>
 
-        <service id="admin.controller.batch" class="%admin.controller.batch.class%" parent="admin.controller.abstract" />
+        <service id="admin.controller.list" class="%admin.controller.list.class%" parent="admin.controller.abstract">
+            <argument>%admin.templates.list%</argument>
+        </service>
+
+        <service id="admin.controller.resource" class="%admin.controller.resource.class%" parent="admin.controller.abstract">
+            <argument>%admin.templates.resource%</argument>
+        </service>
 
         <service id="admin.controller.admin" class="%admin.controller.admin.class%">
             <argument type="service" id="templating"/>

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -11,3 +11,10 @@ the new ones.
 If you were using the `admin.event_dispatcher_aware` tag in order to inject the
 event dispatcher into your services, you will need to change your service definition,
 since the relevant compiler pass was removed.
+
+## Inject template name in your custom contexts
+
+If you have created a context, whose actions can return an HTML response, you need
+to have it return a default value for the template name. This stems from the change
+to controllers [not having](CHANGELOG-3.0.md#default-response-templates-are-injected-into-contexts)
+a default template name injected to them.

--- a/spec/FSi/Bundle/AdminBundle/Admin/CRUD/Context/ListElementContextSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/Admin/CRUD/Context/ListElementContextSpec.php
@@ -26,7 +26,7 @@ class ListElementContextSpec extends ObjectBehavior
         DataGridInterface $datagrid,
         HandlerInterface $handler
     ) {
-        $this->beConstructedWith([$handler]);
+        $this->beConstructedWith([$handler], 'default_list');
         $element->createDataGrid()->willReturn($datagrid);
         $element->createDataSource()->willReturn($datasource);
         $this->setElement($element);
@@ -37,7 +37,7 @@ class ListElementContextSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('FSi\Bundle\AdminBundle\Admin\Context\ContextInterface');
     }
 
-    function it_have_array_data()
+    function it_has_array_data()
     {
         $this->getData()->shouldBeArray();
         $this->getData()->shouldHaveKeyInArray('datagrid_view');
@@ -45,15 +45,22 @@ class ListElementContextSpec extends ObjectBehavior
         $this->getData()->shouldHaveKeyInArray('element');
     }
 
-    function it_has_template(ListElement $element)
+    function it_returns_default_template_if_element_does_not_have_one(ListElement $element)
     {
-        $element->hasOption('template_list')->willReturn(true);
-        $element->getOption('template_list')->willReturn('this_is_list_template.html.twig');
+        $element->hasOption('template_list')->willReturn(false);
+        $this->getTemplateName()->shouldReturn('default_list');
         $this->hasTemplateName()->shouldReturn(true);
-        $this->getTemplateName()->shouldReturn('this_is_list_template.html.twig');
     }
 
-    function it_handle_request_with_request_handlers(HandlerInterface $handler, Request $request)
+    function it_returns_template_from_element_if_it_has_one(ListElement $element)
+    {
+        $element->hasOption('template_list')->willReturn(true);
+        $element->getOption('template_list')->willReturn('list.html.twig');
+        $this->hasTemplateName()->shouldReturn(true);
+        $this->getTemplateName()->shouldReturn('list.html.twig');
+    }
+
+    function it_handles_request_with_request_handlers(HandlerInterface $handler, Request $request)
     {
         $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\ListEvent'), $request)
             ->shouldBeCalled();
@@ -61,7 +68,7 @@ class ListElementContextSpec extends ObjectBehavior
         $this->handleRequest($request)->shouldReturn(null);
     }
 
-    function it_return_response_from_handler(HandlerInterface $handler, Request $request)
+    function it_returns_response_from_handler(HandlerInterface $handler, Request $request)
     {
         $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\ListEvent'), $request)
             ->willReturn(new Response());

--- a/spec/FSi/Bundle/AdminBundle/Admin/Display/Context/DisplayContextSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/Admin/Display/Context/DisplayContextSpec.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\FSi\Bundle\AdminBundle\Admin\Display\Context;
+
+use FSi\Bundle\AdminBundle\Admin\Context\Request\HandlerInterface;
+use FSi\Bundle\AdminBundle\Admin\Display\Element;
+use FSi\Bundle\AdminBundle\Display\Display;
+use FSi\Component\DataIndexer\DataIndexerInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use stdClass;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+class DisplayContextSpec extends ObjectBehavior
+{
+    function let(
+        Element $element,
+        HandlerInterface $handler,
+        DataIndexerInterface $dataIndexer,
+        stdClass $displayObject,
+        Display $display,
+        Request $request
+    ) {
+        $request->get('id', null)->willReturn('index');
+        $element->getDataIndexer()->willReturn($dataIndexer);
+        $dataIndexer->getData('index')->willReturn($displayObject);
+        $element->createDisplay($displayObject)->willReturn($display);
+
+        $this->beConstructedWith([$handler], 'default_display');
+        $this->setElement($element);
+    }
+
+    function it_is_context()
+    {
+        $this->shouldBeAnInstanceOf('FSi\Bundle\AdminBundle\Admin\Context\ContextInterface');
+    }
+
+    function it_has_array_data(Request $request)
+    {
+        $this->handleRequest($request)->shouldReturn(null);
+        $this->getData()->shouldBeArray();
+        $this->getData()->shouldHaveKeyInArray('display');
+        $this->getData()->shouldHaveKeyInArray('element');
+    }
+
+    function it_returns_default_template_if_element_does_not_have_one(Element $element)
+    {
+        $element->hasOption('template')->willReturn(false);
+        $this->getTemplateName()->shouldReturn('default_display');
+        $this->hasTemplateName()->shouldReturn(true);
+    }
+
+    function it_returns_template_from_element_if_it_has_one(Element $element)
+    {
+        $element->hasOption('template')->willReturn(true);
+        $element->getOption('template')->willReturn('display.html.twig');
+        $this->hasTemplateName()->shouldReturn(true);
+        $this->getTemplateName()->shouldReturn('display.html.twig');
+    }
+
+    function it_handles_request_with_request_handlers(
+        HandlerInterface $handler,
+        Request $request
+    ) {
+        $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\DisplayEvent'), $request)
+            ->shouldBeCalled();
+
+        $this->handleRequest($request)->shouldReturn(null);
+    }
+
+    function it_returns_response_from_handler(HandlerInterface $handler, Request $request)
+    {
+        $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\DisplayEvent'), $request)
+            ->willReturn(new Response());
+
+        $this->handleRequest($request)
+            ->shouldReturnAnInstanceOf('Symfony\Component\HttpFoundation\Response');
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveKeyInArray' => function($subject, $key) {
+                if (!is_array($subject)) {
+                    return false;
+                }
+
+                return array_key_exists($key, $subject);
+            },
+        ];
+    }
+}

--- a/spec/FSi/Bundle/AdminBundle/Admin/ResourceRepository/Context/ResourceRepositoryContextSpec.php
+++ b/spec/FSi/Bundle/AdminBundle/Admin/ResourceRepository/Context/ResourceRepositoryContextSpec.php
@@ -28,14 +28,12 @@ class ResourceRepositoryContextSpec extends ObjectBehavior
         ResourceFormBuilder $resourceFormBuilder,
         FormInterface $form
     ) {
-        $builder->getMap()->willReturn([
-            'resources' => []
-        ]);
+        $builder->getMap()->willReturn(['resources' => []]);
         $element->getResourceFormOptions()->willReturn([]);
         $element->getKey()->willReturn('resources');
         $resourceFormBuilder->build($element)->willReturn($form);
 
-        $this->beConstructedWith([$handler], $resourceFormBuilder);
+        $this->beConstructedWith([$handler], 'default_resource', $resourceFormBuilder);
         $this->setElement($element);
     }
 
@@ -44,14 +42,29 @@ class ResourceRepositoryContextSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf('FSi\Bundle\AdminBundle\Admin\Context\ContextInterface');
     }
 
-    function it_have_array_data()
+    function it_returns_default_template_if_element_has_none(ResourceElement $element)
+    {
+        $element->hasOption('template')->willReturn(false);
+        $this->getTemplateName()->shouldReturn('default_resource');
+        $this->hasTemplateName()->shouldReturn(true);
+    }
+
+    function it_returns_template_from_element_if_it_has_one(ResourceElement $element)
+    {
+        $element->hasOption('template')->willReturn(true);
+        $element->getOption('template')->willReturn('resource.html.twig');
+        $this->hasTemplateName()->shouldReturn(true);
+        $this->getTemplateName()->shouldReturn('resource.html.twig');
+    }
+
+    function it_has_array_data()
     {
         $this->getData()->shouldBeArray();
         $this->getData()->shouldHaveKeyInArray('form');
         $this->getData()->shouldHaveKeyInArray('element');
     }
 
-    function it_handle_request_with_request_handlers(HandlerInterface $handler, Request $request)
+    function it_handles_request_with_request_handlers(HandlerInterface $handler, Request $request)
     {
         $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\FormEvent'), $request)
             ->shouldBeCalled();
@@ -59,7 +72,7 @@ class ResourceRepositoryContextSpec extends ObjectBehavior
         $this->handleRequest($request)->shouldReturn(null);
     }
 
-    function it_return_response_from_handler(HandlerInterface $handler, Request $request)
+    function it_returns_response_from_handler(HandlerInterface $handler, Request $request)
     {
         $handler->handleRequest(Argument::type('FSi\Bundle\AdminBundle\Event\FormEvent'), $request)
             ->willReturn(new Response());


### PR DESCRIPTION
Resolves #257 

- [x] specs for contexts, that check if default template is returned when element does not provide one
- [x] `DisplayContext` spec
- [x] Update changelog